### PR TITLE
fix: 修复暂停后再播放时需要加载2-3s的问题

### DIFF
--- a/harmony/track_player/src/main/ets/RNTrackPlayerTurboModule.ts
+++ b/harmony/track_player/src/main/ets/RNTrackPlayerTurboModule.ts
@@ -456,12 +456,17 @@ export class RNTrackPlayerTurboModule extends TurboModule implements TM.ReactNat
           this.buffered = value;
         }
       })
+      Logger.info(TAG, 'play playerState: ' + this.playerState);
       if (this.player === undefined) {
         return;
       }
-      if (this.playerState === AvplayerStatus.INITIALIZED) {
+      if (this.playerState === AvplayerStatus.INITIALIZED || this.playerState === AvplayerStatus.STOPPED) {
         await this.player.reset();
         Logger.info(TAG, 'play reset success');
+      }
+      if (this.playerState === AvplayerStatus.PAUSED) {
+        await this.player.play();
+        Logger.info(TAG, 'play play success');
       }
       Logger.info(TAG, 'currentTrackIndex: ' + this.currentTrackIndex);
       this.setPlayerUrl(this.queue.get(this.currentTrackIndex).url);
@@ -1011,13 +1016,13 @@ export class RNTrackPlayerTurboModule extends TurboModule implements TM.ReactNat
 
   playerStateListener() {
     this.player.on('stateChange', async (state) => {
+      this.playerState = state as AvplayerStatus;
       switch (state) {
         case AvplayerStatus.IDLE: // This state machine is triggered after the reset interface is successfully invoked.
           Logger.info(TAG, 'state idle called');
           break;
         case AvplayerStatus.INITIALIZED: // This status is reported after the playback source is set.
           Logger.info(TAG, `state initialized called : ${this.currentTrackIndex}`);
-          this.playerState = AvplayerStatus.INITIALIZED;
           // 设置元数据
           if (this.session != null) {
             // 设置元数据
@@ -1045,10 +1050,8 @@ export class RNTrackPlayerTurboModule extends TurboModule implements TM.ReactNat
           Logger.info(TAG, 'stateChange AVPlayer state completed Start play callback.');
           this.isPlaying = false;
           this.currentTimeMs = 0;
-          if (this.playerState === AvplayerStatus.INITIALIZED) {
-            await this.player.reset();
-            Logger.info(TAG, 'play reset success');
-          }
+          await this.player.reset();
+          Logger.info(TAG, 'play reset success');
           this.loopPlay();
           this.setPlayerUrl(this.queue.get(this.currentTrackIndex).url);
           break;


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary

- close #10 
- 修复暂停后再播放时需要加载2-3s的问题
- 监听到状态变化时没有修改本地变量，导致每次播放都还是初始状态，从初始状态进入播放状态需要2-3s


## Test Plan

https://github.com/user-attachments/assets/be9a303d-bbdd-490c-b85e-f6cf8446fb73


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

